### PR TITLE
feat: runtime-async-std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ before_script:
 script:
   - cargo fmt -- --check
   - cargo test --verbose
-  - cargo clippy --all-targets --all-features
+  - cargo test --no-default-features --features=runtime-async-std --verbose
+  - cargo clippy --all-targets
+  - cargo clippy --all-targets --no-default-features --features=runtime-async-std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,23 +12,29 @@ keywords = ["web", "honeycomb", "api"]
 categories = ["network-programming", "asynchronous", "api-bindings", "web-programming"]
 exclude = [".gitignore", ".travis.yml"]
 
+[badges]
+travis-ci = { repository = "nlopes/libhoney-rust", branch = "master" }
+
 [lib]
 name = "libhoney"
 path = "src/lib.rs"
 
-[badges]
-travis-ci = { repository = "nlopes/libhoney-rust", branch = "master" }
+[features]
+default = ["runtime-tokio"]
+runtime-async-std = ["async-std", "surf/curl-client"]
+runtime-tokio = ["tokio", "surf/hyper-client", "parking_lot"]
 
 [dependencies]
+async-std = { version = "1.7.0", default-features = false, features = ["alloc"], optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 crossbeam-channel = "0.5"
 log = "0.4"
-parking_lot = "0.11"
+parking_lot = { version = "0.11", optional = true }
 rand = "0.7"
-reqwest = { version = "0.10.8", features = ["blocking", "json"] }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
-tokio = { version = "0.2", features = ["time"] }
+surf = { version = "2.1.0", default-features = false }
+tokio = { version = "0.2", features = ["rt-threaded", "time"], optional = true }
 
 [dev-dependencies]
 env_logger = "0.8"

--- a/src/client.rs
+++ b/src/client.rs
@@ -166,8 +166,8 @@ mod tests {
 
     #[test]
     fn test_flush() {
-        use reqwest::StatusCode;
         use serde_json::json;
+        use surf::StatusCode;
 
         let api_host = &mockito::server_url();
         let _m = mockito::mock(
@@ -194,7 +194,7 @@ mod tests {
         event.send(&mut client).unwrap();
 
         let response = client.responses().iter().next().unwrap();
-        assert_eq!(response.status_code, Some(StatusCode::ACCEPTED));
+        assert_eq!(response.status_code, Some(StatusCode::Accepted));
         assert_eq!(response.metadata, Some(json!("some metadata in a string")));
 
         client.flush().unwrap();
@@ -205,7 +205,7 @@ mod tests {
         event.send(&mut client).unwrap();
 
         let response = client.responses().iter().next().unwrap();
-        assert_eq!(response.status_code, Some(StatusCode::ACCEPTED));
+        assert_eq!(response.status_code, Some(StatusCode::Accepted));
         assert_eq!(response.metadata, Some(json!("some metadata in a string")));
 
         client.close().unwrap();

--- a/src/event.rs
+++ b/src/event.rs
@@ -175,7 +175,7 @@ impl Event {
 
 #[cfg(test)]
 mod tests {
-    use reqwest::StatusCode;
+    use surf::StatusCode;
 
     use super::*;
     use crate::client;
@@ -227,7 +227,7 @@ mod tests {
         e.send(&mut client).unwrap();
 
         if let Some(only) = client.transmission.responses().iter().next() {
-            assert_eq!(only.status_code, Some(StatusCode::OK));
+            assert_eq!(only.status_code, Some(StatusCode::Ok));
         }
         client.close().unwrap();
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, Instant};
 
-use reqwest::StatusCode;
+use surf::StatusCode;
 
 use crate::event::Event;
 use crate::response::Response;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
-use reqwest::StatusCode;
 use serde::Deserialize;
+use surf::StatusCode;
 
 use crate::Value;
 


### PR DESCRIPTION
Adds a compile-time flag to support running on [async-std](https://crates.io/crates/async-std)'s threadpool rather than a tokio one.

This also switches out Reqwest for [Surf](https://crates.io/crates/surf), which has multiple http client backends, including a Hyper (tokio-compatible) one.

Note: these feature flags are mutually exclusive, and building does not work if none is specified (i.e. `--no-default-features`).

cc @nlopes