### PR TITLE
Add TLS feature flags for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ exclude = [".gitignore", ".travis.yml"]
 name = "libhoney"
 path = "src/lib.rs"
 
+[features]
+default = ["rustls-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+
 [badges]
 travis-ci = { repository = "nlopes/libhoney-rust", branch = "master" }
 
@@ -25,7 +30,7 @@ crossbeam-channel = "0.5"
 log = "0.4"
 parking_lot = "0.11"
 rand = "0.7"
-reqwest = { version = "0.10.8", features = ["blocking", "json"] }
+reqwest = { version = "0.10.8", features = ["blocking", "json"], default-features = false }
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
 tokio = { version = "0.2", features = ["time"] }


### PR DESCRIPTION
Currently, this crate depends on `reqwest` with its default feature
flags, which include `native-tls` and a transitive dependency on
OpenSSL. This PR introduces feature flags to allow users to choose
between `rusttls` and `native-tls`, with the default changing to the
former.