### PR TITLE
Enable tokio time driver

### DIFF
--- a/src/transmission.rs
+++ b/src/transmission.rs
@@ -173,6 +173,7 @@ impl Transmission {
             .thread_stack_size(3 * 1024 * 1024)
             .threaded_scheduler()
             .enable_io()
+            .enable_time()
             .build()?)
     }
 


### PR DESCRIPTION
Without the time driver enabled, I'm seeing the following panic on an `x86_64-unknown-linux-musl` target:
```
thread 'libhoney-rust' panicked at 'there is no timer running, must be called from the context of Tokio runtime', /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/time/driver/handle.rs:25:14
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1076
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1537
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:217
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:526
  11: rust_begin_unwind
             at src/libstd/panicking.rs:437
  12: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
  13: core::option::expect_failed
             at src/libcore/option.rs:1261
  14: core::option::Option<T>::expect
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/option.rs:344
  15: tokio::time::driver::handle::Handle::current
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/time/driver/handle.rs:24
  16: tokio::time::driver::registration::Registration::new
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/time/driver/registration.rs:18
  17: tokio::time::delay::delay_until
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/time/delay.rs:19
  18: tokio::time::interval::interval_at
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/time/interval.rs:104
  19: tokio::time::interval::interval
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/time/interval.rs:70
  20: hyper::client::pool::PoolInner<T>::spawn_idle_interval
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.9/src/client/pool.rs:410
  21: hyper::client::pool::PoolInner<T>::put
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.9/src/client/pool.rs:375
  22: hyper::client::pool::Pool<T>::pooled
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.9/src/client/pool.rs:207
  23: hyper::client::Client<C,B>::connect_to::{{closure}}::{{closure}}::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.9/src/client/mod.rs:527
  24: <T as futures_util::fns::FnOnce1<A>>::call_once
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/fns.rs:15
  25: <futures_util::fns::MapOkFn<F> as futures_util::fns::FnOnce1<core::result::Result<T,E>>>::call_once::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/fns.rs:187
  26: core::result::Result<T,E>::map
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/result.rs:519
  27: <futures_util::fns::MapOkFn<F> as futures_util::fns::FnOnce1<core::result::Result<T,E>>>::call_once
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/fns.rs:187
  28: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/future/map.rs:51
  29: <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  30: <futures_util::future::try_future::MapOk<Fut,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  31: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/future/future.rs:119
  32: <futures_util::future::either::Either<A,B> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/either.rs:63
  33: <F as futures_core::future::TryFuture>::try_poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-core-0.3.8/src/future.rs:83
  34: <futures_util::future::try_future::try_flatten::TryFlatten<Fut,<Fut as futures_core::future::TryFuture>::Ok> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/try_future/try_flatten.rs:54
  35: <futures_util::future::try_future::TryFlatten<Fut1,Fut2> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  36: <futures_util::future::try_future::AndThen<Fut1,Fut2,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  37: <futures_util::future::either::Either<A,B> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/either.rs:63
  38: <hyper::common::lazy::Lazy<F,R> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.9/src/common/lazy.rs:53
  39: futures_util::future::future::FutureExt::poll_unpin
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/future/mod.rs:561
  40: <futures_util::future::select::Select<A,B> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/select.rs:92
  41: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/future/map.rs:49
  42: <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  43: <futures_util::future::future::flatten::Flatten<Fut,<Fut as core::future::future::Future>::Output> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/future/flatten.rs:45
  44: <futures_util::future::future::Then<Fut1,Fut2,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  45: <F as futures_core::future::TryFuture>::try_poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-core-0.3.8/src/future.rs:83
  46: <futures_util::future::try_future::into_future::IntoFuture<Fut> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/try_future/into_future.rs:31
  47: <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/future/map.rs:49
  48: <futures_util::future::future::Map<Fut,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  49: <futures_util::future::try_future::MapOk<Fut,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  50: <F as futures_core::future::TryFuture>::try_poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-core-0.3.8/src/future.rs:83
  51: <futures_util::future::try_future::try_flatten::TryFlatten<Fut,<Fut as futures_core::future::TryFuture>::Ok> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/try_future/try_flatten.rs:45
  52: <futures_util::future::try_future::TryFlatten<Fut1,Fut2> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  53: <futures_util::future::try_future::AndThen<Fut1,Fut2,F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/lib.rs:113
  54: hyper::client::Client<C,B>::retryably_send_request::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.9/src/client/mod.rs:256
  55: <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/poll_fn.rs:54
  56: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/future/future.rs:119
  57: <hyper::client::ResponseFuture as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/hyper-0.13.9/src/client/mod.rs:628
  58: <reqwest::async_impl::client::PendingRequest as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/reqwest-0.10.9/src/async_impl/client.rs:1364
  59: <reqwest::async_impl::client::Pending as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/reqwest-0.10.9/src/async_impl/client.rs:1343
  60: libhoney::transmission::Transmission::send_batch::{{closure}}
             at /Users/daramos/.cargo/git/checkouts/libhoney-rust-3b5a30a6076b74c0/83d1b95/src/transmission.rs:305
  61: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/future/mod.rs:78
  62: libhoney::transmission::Transmission::process_work::{{closure}}::{{closure}}
             at /Users/daramos/.cargo/git/checkouts/libhoney-rust-3b5a30a6076b74c0/83d1b95/src/transmission.rs:251
  63: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/future/mod.rs:78
  64: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/core.rs:173
  65: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/loom/std/unsafe_cell.rs:14
  66: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/core.rs:158
  67: tokio::runtime::task::harness::Harness<T,S>::poll::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/harness.rs:107
  68: core::ops::function::FnOnce::call_once
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/ops/function.rs:233
  69: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/panic.rs:318
  70: std::panicking::try::do_call
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/panicking.rs:348
  71: __rust_try
  72: std::panicking::try
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/panicking.rs:325
  73: std::panic::catch_unwind
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/panic.rs:394
  74: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/harness.rs:89
  75: tokio::runtime::task::raw::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/raw.rs:104
  76: tokio::runtime::task::raw::RawTask::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/raw.rs:66
  77: tokio::runtime::task::Notified<S>::run
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/mod.rs:169
  78: tokio::runtime::thread_pool::worker::Context::run_task::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/thread_pool/worker.rs:370
  79: tokio::coop::with_budget::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/coop.rs:127
  80: std::thread::local::LocalKey<T>::try_with
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/thread/local.rs:263
  81: std::thread::local::LocalKey<T>::with
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/thread/local.rs:239
  82: tokio::coop::with_budget
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/coop.rs:120
  83: tokio::coop::budget
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/coop.rs:96
  84: tokio::runtime::thread_pool::worker::Context::run_task
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/thread_pool/worker.rs:348
  85: tokio::runtime::thread_pool::worker::Context::run
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/thread_pool/worker.rs:320
  86: tokio::runtime::thread_pool::worker::run::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/thread_pool/worker.rs:305
  87: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/macros/scoped_tls.rs:63
  88: tokio::runtime::thread_pool::worker::run
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/thread_pool/worker.rs:302
  89: tokio::runtime::thread_pool::worker::Launch::launch::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/thread_pool/worker.rs:281
  90: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/blocking/task.rs:41
  91: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/core.rs:173
  92: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/loom/std/unsafe_cell.rs:14
  93: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/core.rs:158
  94: tokio::runtime::task::harness::Harness<T,S>::poll::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/harness.rs:107
  95: core::ops::function::FnOnce::call_once
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libcore/ops/function.rs:233
  96: <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/panic.rs:318
  97: std::panicking::try::do_call
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/panicking.rs:348
  98: __rust_try
  99: std::panicking::try
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/panicking.rs:325
 100: std::panic::catch_unwind
             at /Users/daramos/.rustup/toolchains/1.46.0-x86_64-apple-darwin/lib/rustlib/src/rust/src/libstd/panic.rs:394
 101: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/harness.rs:89
 102: tokio::runtime::task::raw::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/raw.rs:104
 103: tokio::runtime::task::raw::RawTask::poll
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/raw.rs:66
 104: tokio::runtime::task::Notified<S>::run
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/task/mod.rs:169
 105: tokio::runtime::blocking::pool::Inner::run
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/blocking/pool.rs:250
 106: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}::{{closure}}
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/blocking/pool.rs:230
 107: tokio::runtime::context::enter
             at /Users/daramos/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/context.rs:72
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
With this patch applied, the error no longer appears.

As a followup suggestion, I think it would be useful to have an interface that accepts an existing Tokio runtime when calling `libhoney::init`. It took me awhile to debug this issue before I realized that `libhoney` had its own runtime! Alternatively, the crate could call [tokio::runtime::Handle::try_current](https://tokio-rs.github.io/tokio/doc/tokio/runtime/struct.Handle.html#method.try_current) and reuse the enclosing runtime if it's called from within one. I haven't done too much work with tokio though, so I'm not sure if that sort of behavior is typical or expected.