### PR TITLE
Reuse HTTP connections between batches

### DIFF
--- a/src/transmission.rs
+++ b/src/transmission.rs
@@ -21,6 +21,9 @@ use crate::events::{Events, EventsResponse};
 use crate::response::{HoneyResponse, Response};
 use crate::sender::Sender;
 
+// Re-export reqwest client to help users avoid versioning issues.
+pub use reqwest::{Client as HttpClient, ClientBuilder as HttpClientBuilder};
+
 const BATCH_ENDPOINT: &str = "/1/batch/";
 
 const DEFAULT_NAME_PREFIX: &str = "libhoney-rust";
@@ -79,7 +82,7 @@ pub struct Transmission {
     user_agent: String,
 
     runtime: Arc<Mutex<Runtime>>,
-    http_client: reqwest::Client,
+    http_client: HttpClient,
 
     work_sender: ChannelSender<Event>,
     work_receiver: ChannelReceiver<Event>,
@@ -200,8 +203,13 @@ impl Transmission {
             response_sender,
             response_receiver,
             user_agent: format!("{}/{}", DEFAULT_NAME_PREFIX, env!("CARGO_PKG_VERSION")),
-            http_client: reqwest::Client::new(),
+            http_client: HttpClient::new(),
         })
+    }
+
+    /// Sets a custom reqwest client.
+    pub fn set_http_client(&mut self, http_client: HttpClient) {
+        self.http_client = http_client;
     }
 
     async fn process_work(

--- a/src/transmission.rs
+++ b/src/transmission.rs
@@ -21,9 +21,6 @@ use crate::events::{Events, EventsResponse};
 use crate::response::{HoneyResponse, Response};
 use crate::sender::Sender;
 
-// Re-export reqwest client to help users avoid versioning issues.
-pub use reqwest::{Client as HttpClient, ClientBuilder as HttpClientBuilder};
-
 const BATCH_ENDPOINT: &str = "/1/batch/";
 
 const DEFAULT_NAME_PREFIX: &str = "libhoney-rust";
@@ -82,7 +79,7 @@ pub struct Transmission {
     user_agent: String,
 
     runtime: Arc<Mutex<Runtime>>,
-    http_client: HttpClient,
+    http_client: reqwest::Client,
 
     work_sender: ChannelSender<Event>,
     work_receiver: ChannelReceiver<Event>,
@@ -203,13 +200,8 @@ impl Transmission {
             response_sender,
             response_receiver,
             user_agent: format!("{}/{}", DEFAULT_NAME_PREFIX, env!("CARGO_PKG_VERSION")),
-            http_client: HttpClient::new(),
+            http_client: reqwest::Client::new(),
         })
-    }
-
-    /// Sets a custom reqwest client.
-    pub fn set_http_client(&mut self, http_client: HttpClient) {
-        self.http_client = http_client;
     }
 
     async fn process_work(


### PR DESCRIPTION
Currently, `send_batch` creates a new reqwest client for each batch,
which results in creating a new HTTPS connection for each batch. This
PR reuses the same reqwest client across batches, which reduces latency
by reusing connections.

This pattern is consistent with the [reqwest docs](https://docs.rs/reqwest/0.10.10/reqwest/struct.Client.html):
> The Client holds a connection pool internally, so it is advised that you create one and reuse it.

This PR also adds some `trace`-level logging, which should have no
effect unless trace logs are explicitly enabled for the `log` crate.