### PR TITLE
Have close/flush return a Future for callers to wait on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,19 +26,22 @@ travis-ci = { repository = "nlopes/libhoney-rust", branch = "master" }
 
 [dependencies]
 async-channel = "1.5"
-async-std = { version = "1.8", features = ["attributes"] }
+# Need the `unstable` feature to enable `Condvar`. Note that this is unrelated to unstable Rust
+# features and does not require a nightly Rust. This pins to the exact version since unstable
+# features may not respect SemVer.
+async-std = { version = "1.9.0", features = ["unstable"] }
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-crossbeam-utils = "0.8"
+derivative = "2.2"
 futures = "0.3"
 log = "0.4"
-parking_lot = "0.11"
 rand = "0.8"
 reqwest = { version = "0.11.0", features = ["blocking", "json"], default-features = false }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.61"
-tokio = { version = "1.0", features = ["time"], default-features = false }
 
 [dev-dependencies]
+async_executors = { version = "0.4", features = ["async_std", "tokio_tp"] }
 env_logger = "0.8"
 mockito = "0.28"
+tokio = { version = "1.0", features = ["time"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,12 @@ rustls-tls = ["reqwest/rustls-tls"]
 travis-ci = { repository = "nlopes/libhoney-rust", branch = "master" }
 
 [dependencies]
+async-channel = "1.5"
+async-std = { version = "1.8", features = ["attributes"] }
+async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
-crossbeam-channel = "0.5"
+crossbeam-utils = "0.8"
+futures = "0.3"
 log = "0.4"
 parking_lot = "0.11"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ async-channel = "1.5"
 # features may not respect SemVer.
 async-std = { version = "1.9.0", features = ["unstable"] }
 async-trait = "0.1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 derivative = "2.2"
 futures = "0.3"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ data.insert("payload_length".to_string(), json!(27));
 let mut ev = client.new_event();
 ev.add(data);
  // In production code, please check return of `.send()`
-ev.send(&mut client).err();
+ev.send(&mut client).await.err();
 ```
 
 [API reference]: https://docs.rs/libhoney-rust

--- a/README.md
+++ b/README.md
@@ -37,14 +37,23 @@ up background threads to handle sending all the events. Calling .close() on the 
 will terminate all background threads.
 
 ```rust
-let client = libhoney::init(libhoney::Config{
+use std::sync::Arc;
+use async_executors::TokioTpBuilder;
+
+let mut builder = TokioTpBuilder::new();
+builder
+  .tokio_builder()
+  .enable_io();
+let executor = Arc::new(builder.build().expect("failed to build Tokio executor"));
+let client = libhoney::init(libhoney::Config {
+  executor,
   options: libhoney::client::Options {
     api_key: "YOUR_API_KEY".to_string(),
     dataset: "honeycomb-rust-example".to_string(),
     ..libhoney::client::Options::default()
   },
   transmission_options: libhoney::transmission::Options::default(),
-});
+}).expect("failed to spawn Honeycomb client");
 
 client.close();
 ```
@@ -112,23 +121,34 @@ you.
 #### Simple: send an event
 ```rust
 
+use std::sync::Arc;
 use libhoney::FieldHolder; // Add trait to allow for adding fields
-// Call init to get a client
-let mut client = init(libhoney::Config {
-  options: options,
-  transmission_options: libhoney::transmission::Options::default(),
-});
+use async_executors::TokioTpBuilder;
 
-let mut data: HashMap<String, Value> = HashMap::new();
-data.insert("duration_ms".to_string(), json!(153.12));
-data.insert("method".to_string(), Value::String("get".to_string()));
-data.insert("hostname".to_string(), Value::String("appserver15".to_string()));
-data.insert("payload_length".to_string(), json!(27));
+let mut builder = TokioTpBuilder::new();
+builder
+  .tokio_builder()
+  .enable_io();
+let executor = Arc::new(builder.build().expect("failed to build Tokio executor"));
+executor.block_on(async {
+  // Call init to get a client
+  let mut client = init(libhoney::Config {
+    executor: executor.clone(),
+    options: options,
+    transmission_options: libhoney::transmission::Options::default(),
+  }).expect("failed to spawn Honeycomb client");
 
-let mut ev = client.new_event();
-ev.add(data);
- // In production code, please check return of `.send()`
-ev.send(&mut client).await.err();
+  let mut data: HashMap<String, Value> = HashMap::new();
+  data.insert("duration_ms".to_string(), json!(153.12));
+  data.insert("method".to_string(), Value::String("get".to_string()));
+  data.insert("hostname".to_string(), Value::String("appserver15".to_string()));
+  data.insert("payload_length".to_string(), json!(27));
+
+  let mut ev = client.new_event();
+  ev.add(data);
+   // In production code, please check return of `.send()`
+  ev.send(&mut client).await.err();
+})
 ```
 
 [API reference]: https://docs.rs/libhoney-rust

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,17 +1,28 @@
-use libhoney::{Error, FieldHolder};
+use std::sync::Arc;
 
-#[async_std::main]
-async fn main() -> Result<(), Error> {
+use async_executors::TokioTpBuilder;
+use libhoney::{Error, FieldHolder, FutureExecutor};
+
+fn main() -> Result<(), Error> {
     env_logger::init();
 
+    let mut builder = TokioTpBuilder::new();
+    builder.tokio_builder().enable_io().enable_time();
+    let executor = Arc::new(builder.build().expect("failed to build Tokio executor"));
+    executor.block_on(async_main(executor.clone()))
+}
+
+async fn async_main(executor: FutureExecutor) -> Result<(), Error> {
     let client = libhoney::init(libhoney::Config {
+        executor,
         options: libhoney::client::Options {
             api_key: std::env::var("HONEYCOMB_API_KEY").expect("need to set HONEYCOMB_API_KEY"),
             dataset: std::env::var("HONEYCOMB_DATASET").expect("need to set HONEYCOMB_DATASET"),
             ..Default::default()
         },
         transmission_options: libhoney::transmission::Options::default(),
-    });
+    })
+    .expect("failed to spawn Honeycomb client");
     let mut event = client.new_event();
     event.add_field("extra", libhoney::Value::String("wheeee".to_string()));
     event.add_field("extra_ham", libhoney::Value::String("cheese".to_string()));

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,9 +1,10 @@
 use libhoney::{Error, FieldHolder};
 
-fn main() -> Result<(), Error> {
+#[async_std::main]
+async fn main() -> Result<(), Error> {
     env_logger::init();
 
-    let mut client = libhoney::init(libhoney::Config {
+    let client = libhoney::init(libhoney::Config {
         options: libhoney::client::Options {
             api_key: std::env::var("HONEYCOMB_API_KEY").expect("need to set HONEYCOMB_API_KEY"),
             dataset: std::env::var("HONEYCOMB_DATASET").expect("need to set HONEYCOMB_DATASET"),
@@ -14,14 +15,15 @@ fn main() -> Result<(), Error> {
     let mut event = client.new_event();
     event.add_field("extra", libhoney::Value::String("wheeee".to_string()));
     event.add_field("extra_ham", libhoney::Value::String("cheese".to_string()));
-    match event.send(&mut client) {
+    match event.send(&client).await {
         Ok(()) => {
-            let response = client.responses().iter().next().unwrap();
+            let response = client.responses().recv().await.unwrap();
             assert_eq!(response.error, None);
         }
         Err(e) => {
             log::error!("Could not send event: {}", e);
         }
     }
-    client.close()
+    client.close().await?;
+    Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -105,13 +105,11 @@ where
     }
 
     /// close waits for all in-flight messages to be sent. You should call close() before
-    /// app termination. The returned `Transmission` should be dropped outside of a Tokio
-    /// async context so that the contained runtime can be dropped safely. Otherwise, Tokio
-    /// will panic when dropping the runtime.
-    pub async fn close(mut self) -> Result<T> {
+    /// app termination.
+    pub async fn close(mut self) -> Result<()> {
         info!("closing libhoney client");
         self.transmission.stop().await?.await?;
-        Ok(self.transmission)
+        Ok(())
     }
 
     /// flush closes and reopens the Transmission, ensuring events are sent before returning.

--- a/src/client.rs
+++ b/src/client.rs
@@ -105,11 +105,13 @@ where
     }
 
     /// close waits for all in-flight messages to be sent. You should call close() before
-    /// app termination.
-    pub async fn close(mut self) -> Result<()> {
+    /// app termination. The returned `Transmission` should be dropped outside of a Tokio
+    /// async context so that the contained runtime can be dropped safely. Otherwise, Tokio
+    /// will panic when dropping the runtime.
+    pub async fn close(mut self) -> Result<T> {
         info!("closing libhoney client");
         self.transmission.stop().await?.await?;
-        Ok(())
+        Ok(self.transmission)
     }
 
     /// flush closes and reopens the Transmission, ensuring events are sent before returning.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io;
 
 use futures::channel::oneshot;
+use futures::task::SpawnError;
 
 /// Result shorthand for a `std::result::Result` wrapping our own `Error`
 pub type Result<T> = std::result::Result<T, Error>;
@@ -23,6 +24,9 @@ pub enum ErrorKind {
 
     /// Any IO related error
     Io,
+
+    /// Failed to spawn future
+    Spawn,
 }
 
 /// Error
@@ -95,5 +99,10 @@ impl<T> From<async_channel::SendError<T>> for Error {
 impl From<oneshot::Canceled> for Error {
     fn from(e: oneshot::Canceled) -> Self {
         Self::with_description(&e.to_string(), ErrorKind::ChannelError)
+    }
+}
+impl From<SpawnError> for Error {
+    fn from(e: SpawnError) -> Self {
+        Self::with_description(&e.to_string(), ErrorKind::Spawn)
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::io;
 
+use futures::channel::oneshot;
+
 /// Result shorthand for a `std::result::Result` wrapping our own `Error`
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -84,8 +86,14 @@ impl From<io::Error> for Error {
     }
 }
 
-impl<T> From<crossbeam_channel::SendError<T>> for Error {
-    fn from(e: crossbeam_channel::SendError<T>) -> Self {
+impl<T> From<async_channel::SendError<T>> for Error {
+    fn from(e: async_channel::SendError<T>) -> Self {
+        Self::with_description(&e.to_string(), ErrorKind::ChannelError)
+    }
+}
+
+impl From<oneshot::Canceled> for Error {
+    fn from(e: oneshot::Canceled) -> Self {
         Self::with_description(&e.to_string(), ErrorKind::ChannelError)
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -78,12 +78,12 @@ impl Event {
     ///
     /// Once you send an event, any addition calls to add data to that event will return
     /// without doing anything. Once the event is sent, it becomes immutable.
-    pub fn send<T: Sender>(&mut self, client: &mut client::Client<T>) -> Result<()> {
+    pub async fn send<T: Sender>(&mut self, client: &client::Client<T>) -> Result<()> {
         if self.should_drop() {
             info!("dropping event due to sampling");
             return Ok(());
         }
-        self.send_presampled(client)
+        self.send_presampled(client).await
     }
 
     /// `send_presampled` dispatches the event to be sent to Honeycomb.
@@ -100,7 +100,7 @@ impl Event {
     ///
     /// Once you `send` an event, any addition calls to add data to that event will return
     /// without doing anything. Once the event is sent, it becomes immutable.
-    pub fn send_presampled<T: Sender>(&mut self, client: &mut client::Client<T>) -> Result<()> {
+    pub async fn send_presampled<T: Sender>(&mut self, client: &client::Client<T>) -> Result<()> {
         if self.fields.is_empty() {
             return Err(Error::missing_event_fields());
         }
@@ -118,7 +118,7 @@ impl Event {
         }
 
         self.sent = true;
-        client.transmission.send(self.clone());
+        client.transmission.send(self.clone()).await;
         Ok(())
     }
 
@@ -158,19 +158,6 @@ impl Event {
         }
         rand::thread_rng().gen_range(0..self.options.sample_rate) != 0
     }
-
-    pub(crate) fn stop_event() -> Self {
-        let mut h: HashMap<String, Value> = HashMap::new();
-        h.insert("internal_stop_event".to_string(), Value::Null);
-
-        Self {
-            options: client::Options::default(),
-            timestamp: Utc::now(),
-            fields: h,
-            metadata: None,
-            sent: false,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -193,8 +180,8 @@ mod tests {
         assert_eq!(e.fields["my_timestamp"], now);
     }
 
-    #[test]
-    fn test_send() {
+    #[async_std::test]
+    async fn test_send() {
         use crate::transmission;
 
         let api_host = &mockito::server_url();
@@ -213,7 +200,7 @@ mod tests {
             ..client::Options::default()
         };
 
-        let mut client = client::Client::new(
+        let client = client::Client::new(
             options.clone(),
             transmission::Transmission::new(transmission::Options {
                 max_batch_size: 1,
@@ -224,16 +211,16 @@ mod tests {
 
         let mut e = Event::new(&options);
         e.add_field("field_name", Value::String("field_value".to_string()));
-        e.send(&mut client).unwrap();
+        e.send(&client).await.unwrap();
 
-        if let Some(only) = client.transmission.responses().iter().next() {
+        if let Ok(only) = client.transmission.responses().recv().await {
             assert_eq!(only.status_code, Some(StatusCode::OK));
         }
-        client.close().unwrap();
+        client.close().await.unwrap();
     }
 
-    #[test]
-    fn test_empty() {
+    #[async_std::test]
+    async fn test_empty() {
         use crate::errors::ErrorKind;
         use crate::transmission;
 
@@ -247,7 +234,7 @@ mod tests {
         .with_body("[{ \"status\": 200 }]")
         .create();
 
-        let mut client = client::Client::new(
+        let client = client::Client::new(
             client::Options {
                 api_key: "some api key".to_string(),
                 api_host: api_host.to_string(),
@@ -262,9 +249,9 @@ mod tests {
 
         let mut e = client.new_event();
         assert_eq!(
-            e.send(&mut client).err().unwrap().kind,
+            e.send(&client).await.err().unwrap().kind,
             ErrorKind::MissingEventFields
         );
-        client.close().unwrap();
+        client.close().await.unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ pub use client::Client;
 pub use errors::{Error, ErrorKind, Result};
 pub use event::{Event, Metadata};
 pub use fields::FieldHolder;
+pub use response::Response;
 pub use sender::Sender;
 pub use serde_json::{json, Value};
 use transmission::Transmission;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ you.
 
 ### Simple: send an event
 ```rust
+# async fn async_fn() {
 # use std::collections::HashMap;
 # use serde_json::{json, Value};
 # use libhoney::{init, Config};
@@ -133,7 +134,8 @@ data.insert("payload_length".to_string(), json!(27));
 let mut ev = client.new_event();
 ev.add(data);
  // In production code, please check return of `.send()`
-ev.send(&mut client).err();
+ev.send(&mut client).await.err();
+# }
 ```
 
 [API reference]: https://docs.rs/libhoney-rust
@@ -204,13 +206,13 @@ pub mod test {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_init() {
+    #[async_std::test]
+    async fn test_init() {
         let client = init(Config {
             options: client::Options::default(),
             transmission_options: transmission::Options::default(),
         });
-        assert_eq!(client.options.dataset, "librust-dataset");
-        client.close().unwrap();
+        assert_eq!(client.new_builder().options.dataset, "librust-dataset");
+        client.close().await.unwrap();
     }
 }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -31,8 +31,9 @@ impl Sender for TransmissionMock {
     }
 
     // `start` initializes any background processes necessary to send events
-    fn start(&mut self) {
+    fn start(&mut self) -> Result<()> {
         self.started += 1;
+        Ok(())
     }
 
     // `stop` flushes any pending queues and blocks until everything in flight has

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,29 +1,33 @@
 /*!
 Mock module to ease testing
     */
-use crossbeam_channel::{bounded, Receiver};
+use async_channel::{bounded, Receiver};
+use async_std::sync::Mutex;
+use async_trait::async_trait;
+use futures::future;
 
 use crate::response::Response;
-use crate::sender::Sender;
+use crate::sender::{Sender, StopFuture};
 use crate::transmission::Options;
 use crate::Event;
 use crate::Result;
 
 /// Transmission mocker for use in tests (mostly in beeline-rust)
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TransmissionMock {
     started: usize,
     stopped: usize,
     events_called: usize,
-    events: Vec<Event>,
+    events: Mutex<Vec<Event>>,
     responses: Receiver<Response>,
     block_on_responses: bool,
 }
 
+#[async_trait]
 impl Sender for TransmissionMock {
     // `send` queues up an event to be sent
-    fn send(&mut self, ev: Event) {
-        self.events.push(ev);
+    async fn send(&self, ev: Event) {
+        self.events.lock().await.push(ev);
     }
 
     // `start` initializes any background processes necessary to send events
@@ -33,9 +37,9 @@ impl Sender for TransmissionMock {
 
     // `stop` flushes any pending queues and blocks until everything in flight has
     // been sent
-    fn stop(&mut self) -> Result<()> {
+    async fn stop(&mut self) -> Result<StopFuture> {
         self.stopped += 1;
-        Ok(())
+        Ok(Box::new(future::ready(Ok(()))))
     }
 
     // `responses` returns a channel that will contain a single Response for each
@@ -53,15 +57,15 @@ impl TransmissionMock {
             started: 0,
             stopped: 0,
             events_called: 0,
-            events: Vec::new(),
+            events: Mutex::new(Vec::new()),
             block_on_responses: false,
             responses,
         })
     }
 
     /// events
-    pub fn events(&mut self) -> Vec<Event> {
+    pub async fn events(&mut self) -> Vec<Event> {
         self.events_called += 1;
-        self.events.clone()
+        self.events.lock().await.clone()
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -22,7 +22,7 @@ pub trait Sender {
     async fn send(&self, ev: Event);
 
     /// `start` initializes any background processes necessary to send events
-    fn start(&mut self);
+    fn start(&mut self) -> Result<()>;
 
     /// `stop` flushes any pending queues and blocks until everything in flight has been
     /// sent. The returned oneshot receiver is notified when all events have been flushed.

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,21 +1,35 @@
-use crossbeam_channel::Receiver;
+use async_channel::Receiver;
+use async_trait::async_trait;
+use futures::channel::oneshot;
+use futures::Future;
 
 use crate::errors::Result;
 use crate::response::Response;
 use crate::Event;
 
+/// A Future that callers can await to determine when stop/flush has completed.
+pub type StopFuture =
+    Box<dyn Future<Output = std::result::Result<(), oneshot::Canceled>> + Send + Sync + Unpin>;
+
 /// `Sender` is responsible for handling events after Send() is called.  Implementations
 /// of `send()` must be safe for concurrent calls.
+#[async_trait]
 pub trait Sender {
-    /// `send` queues up an event to be sent
-    fn send(&mut self, ev: Event);
+    /// `send` queues up an event to be sent.
+    ///
+    /// If the work queue is full, this function blocks the current task until the
+    /// event can be enqueued.
+    async fn send(&self, ev: Event);
 
     /// `start` initializes any background processes necessary to send events
     fn start(&mut self);
 
     /// `stop` flushes any pending queues and blocks until everything in flight has been
-    /// sent
-    fn stop(&mut self) -> Result<()>;
+    /// sent. The returned oneshot receiver is notified when all events have been flushed.
+    ///
+    /// If the work queue is full, this function blocks the current task until the stop
+    /// event can be enqueued.
+    async fn stop(&mut self) -> Result<StopFuture>;
 
     /// `responses` returns a channel that will contain a single Response for each Event
     /// added. Note that they may not be in the same order as they came in

--- a/src/transmission.rs
+++ b/src/transmission.rs
@@ -7,13 +7,14 @@ use std::time::{Duration, Instant};
 
 use async_channel::{bounded, Receiver as ChannelReceiver, Sender as ChannelSender};
 use async_std::future;
+use async_std::sync::{Condvar, Mutex};
 use async_trait::async_trait;
-use crossbeam_utils::sync::WaitGroup;
+use derivative::Derivative;
 use futures::channel::oneshot;
 use futures::executor;
+use futures::task::{Spawn, SpawnExt};
 use log::{debug, error, info, trace};
 use reqwest::{header, StatusCode};
-use tokio::runtime::{Builder, Runtime};
 
 use crate::errors::{Error, Result};
 use crate::event::Event;
@@ -21,6 +22,7 @@ use crate::eventdata::EventData;
 use crate::events::{Events, EventsResponse};
 use crate::response::{HoneyResponse, Response};
 use crate::sender::{Sender, StopFuture};
+use crate::FutureExecutor;
 
 // Re-export reqwest client to help users avoid versioning issues.
 pub use reqwest::{Client as HttpClient, ClientBuilder as HttpClientBuilder};
@@ -83,12 +85,14 @@ enum QueueEvent {
 }
 
 /// `Transmission` handles collecting and sending individual events to Honeycomb
-#[derive(Debug, Clone)]
+#[derive(Derivative, Clone)]
+#[derivative(Debug)]
 pub struct Transmission {
     pub(crate) options: Options,
     user_agent: String,
 
-    runtime: Arc<Runtime>,
+    #[derivative(Debug = "ignore")]
+    executor: FutureExecutor,
     http_client: reqwest::Client,
 
     work_sender: ChannelSender<QueueEvent>,
@@ -109,23 +113,26 @@ impl Drop for Transmission {
 
 #[async_trait]
 impl Sender for Transmission {
-    fn start(&mut self) {
+    fn start(&mut self) -> Result<()> {
         let work_receiver = self.work_receiver.clone();
         let response_sender = self.response_sender.clone();
         let options = self.options.clone();
         let user_agent = self.user_agent.clone();
-        let runtime = self.runtime.clone();
+        let executor = self.executor.clone();
         let http_client = self.http_client.clone();
 
         info!("transmission starting");
         // Task that processes all the work received.
-        runtime.handle().spawn(Self::process_work(
-            work_receiver,
-            response_sender,
-            options,
-            user_agent,
-            http_client,
-        ));
+        executor
+            .spawn(Self::process_work(
+                work_receiver,
+                response_sender,
+                executor.clone(),
+                options,
+                user_agent,
+                http_client,
+            ))
+            .map_err(Error::from)
     }
 
     async fn stop(&mut self) -> Result<StopFuture> {
@@ -188,30 +195,57 @@ impl Sender for Transmission {
     }
 }
 
-impl Transmission {
-    fn new_runtime(options: Option<&Options>) -> Result<Runtime> {
-        let mut builder = Builder::new_multi_thread();
-        if let Some(opts) = options {
-            // Allows one thread for coordinating the batches and `max_concurrent_batches` threads
-            // for sending them to Honeycomb.
-            builder.worker_threads(opts.max_concurrent_batches + 1);
-        };
-        Ok(builder
-            .thread_name("libhoney-rust")
-            .thread_stack_size(3 * 1024 * 1024)
-            .enable_io()
-            .enable_time()
-            .build()?)
+struct BatchWaiter {
+    batches_in_progress: Arc<Mutex<usize>>,
+    condvar: Arc<Condvar>,
+}
+impl BatchWaiter {
+    pub fn new() -> Self {
+        Self {
+            batches_in_progress: Arc::new(Mutex::new(0)),
+            condvar: Arc::new(Condvar::new()),
+        }
     }
 
-    pub(crate) fn new(options: Options) -> Result<Self> {
-        let runtime = Self::new_runtime(Some(&options))?;
+    // Takes a mutable reference so that only the top-level caller can spawn batches.
+    pub async fn start_batch(&mut self) -> BatchWaiterGuard {
+        let mut lock_guard = self.batches_in_progress.lock().await;
+        *lock_guard += 1;
+        BatchWaiterGuard {
+            batches_in_progress: self.batches_in_progress.clone(),
+            condvar: self.condvar.clone(),
+        }
+    }
 
+    pub async fn wait_for_completion(self) {
+        let mut lock_guard = self.batches_in_progress.lock().await;
+        while *lock_guard != 0 {
+            lock_guard = self.condvar.wait(lock_guard).await;
+        }
+    }
+}
+
+#[must_use]
+struct BatchWaiterGuard {
+    batches_in_progress: Arc<Mutex<usize>>,
+    condvar: Arc<Condvar>,
+}
+impl BatchWaiterGuard {
+    // We can't implement this using Drop since Drop::drop can't use async.
+    async fn end_batch(self) {
+        let mut lock_guard = self.batches_in_progress.lock().await;
+        *lock_guard -= 1;
+        self.condvar.notify_one();
+    }
+}
+
+impl Transmission {
+    pub(crate) fn new(executor: FutureExecutor, options: Options) -> Result<Self> {
         let (work_sender, work_receiver) = bounded(options.pending_work_capacity * 4);
         let (response_sender, response_receiver) = bounded(options.pending_work_capacity * 4);
 
         Ok(Self {
-            runtime: Arc::new(runtime),
+            executor,
             options,
             work_sender,
             work_receiver,
@@ -230,14 +264,14 @@ impl Transmission {
     async fn process_work(
         work_receiver: ChannelReceiver<QueueEvent>,
         response_sender: ChannelSender<Response>,
+        executor: Arc<dyn Spawn + Send + Sync>,
         options: Options,
         user_agent: String,
         http_client: reqwest::Client,
     ) {
         let mut batches: HashMap<String, Events> = HashMap::new();
         let mut expired = false;
-        // Used for waiting on every task spawned by this worker thread to complete.
-        let wait_group = WaitGroup::new();
+        let mut batches_in_progress = BatchWaiter::new();
 
         let stop_sender = loop {
             let options = options.clone();
@@ -307,11 +341,9 @@ impl Transmission {
                     //   "You do not have to wrap the Client it in an Rc or Arc to reuse it, because
                     //    it already uses an Arc internally."
                     let client_copy = http_client.clone();
-                    let wait_group_copy = wait_group.clone();
 
-                    tokio::task::spawn(async move {
-                        // When this is dropped, it removes the task from the wait group.
-                        let _wait_group = wait_group_copy;
+                    let batch_guard = batches_in_progress.start_batch().await;
+                    match executor.spawn(async move {
                         for response in Self::send_batch(
                             batch_copy,
                             options,
@@ -326,7 +358,14 @@ impl Transmission {
                                 .await
                                 .expect("unable to enqueue batch response");
                         }
-                    });
+                        batch_guard.end_batch().await;
+                    }) {
+                        Ok(_) => {}
+                        Err(spawn_err) => {
+                            error!("Failed to spawn task to send batch: {}", spawn_err);
+                        }
+                    }
+
                     batches_sent.push(batch_name.to_string())
                 }
             }
@@ -347,11 +386,7 @@ impl Transmission {
         // Wait for all in-progress batches to be sent before completing the worker task. This
         // ensures that waiting on the worker task to complete also waits on any batches to
         // finish being sent.
-        tokio::task::block_in_place(move || {
-            trace!("waiting for pending batches to be sent");
-            wait_group.wait();
-            trace!("no batches remaining");
-        });
+        batches_in_progress.wait_for_completion().await;
 
         if let Some(sender) = stop_sender {
             sender.send(()).unwrap_or_else(|()| {
@@ -448,60 +483,72 @@ mod tests {
 
     use super::*;
     use crate::client;
+    use crate::test::run_with_supported_executors;
 
     #[test]
     fn test_defaults() {
-        let transmission = Transmission::new(Options::default()).unwrap();
-        assert_eq!(
-            transmission.user_agent,
-            format!("{}/{}", DEFAULT_NAME_PREFIX, env!("CARGO_PKG_VERSION"))
-        );
+        run_with_supported_executors(|executor| async move {
+            let transmission = Transmission::new(executor, Options::default()).unwrap();
+            assert_eq!(
+                transmission.user_agent,
+                format!("{}/{}", DEFAULT_NAME_PREFIX, env!("CARGO_PKG_VERSION"))
+            );
 
-        assert_eq!(transmission.options.max_batch_size, DEFAULT_MAX_BATCH_SIZE);
-        assert_eq!(transmission.options.batch_timeout, DEFAULT_BATCH_TIMEOUT);
-        assert_eq!(
-            transmission.options.max_concurrent_batches,
-            DEFAULT_MAX_CONCURRENT_BATCHES
-        );
-        assert_eq!(
-            transmission.options.pending_work_capacity,
-            DEFAULT_PENDING_WORK_CAPACITY
-        );
+            assert_eq!(transmission.options.max_batch_size, DEFAULT_MAX_BATCH_SIZE);
+            assert_eq!(transmission.options.batch_timeout, DEFAULT_BATCH_TIMEOUT);
+            assert_eq!(
+                transmission.options.max_concurrent_batches,
+                DEFAULT_MAX_CONCURRENT_BATCHES
+            );
+            assert_eq!(
+                transmission.options.pending_work_capacity,
+                DEFAULT_PENDING_WORK_CAPACITY
+            );
+        })
     }
 
     #[test]
     fn test_modifiable_defaults() {
-        let transmission = Transmission::new(Options {
-            user_agent_addition: Some(" something/0.3".to_string()),
-            ..Options::default()
+        run_with_supported_executors(|executor| async move {
+            let transmission = Transmission::new(
+                executor,
+                Options {
+                    user_agent_addition: Some(" something/0.3".to_string()),
+                    ..Options::default()
+                },
+            )
+            .unwrap();
+            assert_eq!(
+                transmission.options.user_agent_addition,
+                Some(" something/0.3".to_string())
+            );
         })
-        .unwrap();
-        assert_eq!(
-            transmission.options.user_agent_addition,
-            Some(" something/0.3".to_string())
-        );
     }
 
-    #[async_std::test]
-    async fn test_responses() {
-        use crate::fields::FieldHolder;
+    #[test]
+    fn test_responses() {
+        run_with_supported_executors(|executor| async move {
+            use crate::fields::FieldHolder;
 
-        let mut transmission = Transmission::new(Options {
-            max_batch_size: 5,
-            ..Options::default()
-        })
-        .unwrap();
-        transmission.start();
+            let mut transmission = Transmission::new(
+                executor,
+                Options {
+                    max_batch_size: 5,
+                    ..Options::default()
+                },
+            )
+            .unwrap();
+            transmission.start().unwrap();
 
-        let api_host = &mockito::server_url();
-        let _m = mockito::mock(
-            "POST",
-            mockito::Matcher::Regex(r"/1/batch/(.*)$".to_string()),
-        )
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(
-            r#"
+            let api_host = &mockito::server_url();
+            let _m = mockito::mock(
+                "POST",
+                mockito::Matcher::Regex(r"/1/batch/(.*)$".to_string()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
 [
   { "status":202 },
   { "status":202 },
@@ -510,177 +557,190 @@ mod tests {
   { "status":202 }
 ]
 "#,
-        )
-        .create();
+            )
+            .create();
 
-        for i in 0i32..5 {
+            for i in 0i32..5 {
+                let mut event = Event::new(&client::Options {
+                    api_key: "some_api_key".to_string(),
+                    api_host: api_host.to_string(),
+                    ..client::Options::default()
+                });
+                event.add_field("id", serde_json::from_str(&i.to_string()).unwrap());
+                transmission.send(event).await;
+            }
+            for _i in 0i32..5 {
+                let response = transmission.responses().recv().await.unwrap();
+                assert_eq!(response.status_code, Some(StatusCode::ACCEPTED));
+                assert_eq!(response.body, None);
+            }
+            transmission.stop().await.unwrap().await.unwrap();
+        })
+    }
+
+    #[test]
+    fn test_metadata() {
+        run_with_supported_executors(|executor| async move {
+            use serde_json::json;
+
+            let mut transmission = Transmission::new(
+                executor,
+                Options {
+                    max_batch_size: 1,
+                    ..Options::default()
+                },
+            )
+            .unwrap();
+            transmission.start().unwrap();
+
+            let api_host = &mockito::server_url();
+            let _m = mockito::mock(
+                "POST",
+                mockito::Matcher::Regex(r"/1/batch/(.*)$".to_string()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
+[
+  { "status":202 }
+]
+"#,
+            )
+            .create();
+
+            let metadata = Some(json!("some metadata in a string"));
             let mut event = Event::new(&client::Options {
                 api_key: "some_api_key".to_string(),
                 api_host: api_host.to_string(),
                 ..client::Options::default()
             });
-            event.add_field("id", serde_json::from_str(&i.to_string()).unwrap());
+            event.metadata = metadata.clone();
             transmission.send(event).await;
-        }
-        for _i in 0i32..5 {
-            let response = transmission.responses().recv().await.unwrap();
-            assert_eq!(response.status_code, Some(StatusCode::ACCEPTED));
-            assert_eq!(response.body, None);
-        }
-        transmission.stop().await.unwrap().await.unwrap();
+
+            if let Ok(response) = transmission.responses().recv().await {
+                assert_eq!(response.status_code, Some(StatusCode::ACCEPTED));
+                assert_eq!(response.metadata, metadata);
+            } else {
+                panic!("did not receive an expected response");
+            }
+            transmission.stop().await.unwrap().await.unwrap();
+        })
     }
 
-    #[async_std::test]
-    async fn test_metadata() {
-        use serde_json::json;
+    #[test]
+    fn test_multiple_batches() {
+        run_with_supported_executors(|executor| async move {
+            // What we try to test here is if events are sent in separate batches, depending
+            // on their combination of api_host, api_key, dataset.
+            //
+            // For that, we set max_batch_size to 2, then we send 3 events, 2 with one
+            // combination and 1 with another.  Only the two should be sent, and we should get
+            // back two responses.
+            use serde_json::json;
+            let mut transmission = Transmission::new(
+                executor,
+                Options {
+                    max_batch_size: 2,
+                    batch_timeout: Duration::from_secs(5),
+                    ..Options::default()
+                },
+            )
+            .unwrap();
+            transmission.start().unwrap();
 
-        let mut transmission = Transmission::new(Options {
-            max_batch_size: 1,
-            ..Options::default()
-        })
-        .unwrap();
-        transmission.start();
-
-        let api_host = &mockito::server_url();
-        let _m = mockito::mock(
-            "POST",
-            mockito::Matcher::Regex(r"/1/batch/(.*)$".to_string()),
-        )
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(
-            r#"
-[
-  { "status":202 }
-]
-"#,
-        )
-        .create();
-
-        let metadata = Some(json!("some metadata in a string"));
-        let mut event = Event::new(&client::Options {
-            api_key: "some_api_key".to_string(),
-            api_host: api_host.to_string(),
-            ..client::Options::default()
-        });
-        event.metadata = metadata.clone();
-        transmission.send(event).await;
-
-        if let Ok(response) = transmission.responses().recv().await {
-            assert_eq!(response.status_code, Some(StatusCode::ACCEPTED));
-            assert_eq!(response.metadata, metadata);
-        } else {
-            panic!("did not receive an expected response");
-        }
-        transmission.stop().await.unwrap().await.unwrap();
-    }
-
-    #[async_std::test]
-    async fn test_multiple_batches() {
-        // What we try to test here is if events are sent in separate batches, depending
-        // on their combination of api_host, api_key, dataset.
-        //
-        // For that, we set max_batch_size to 2, then we send 3 events, 2 with one
-        // combination and 1 with another.  Only the two should be sent, and we should get
-        // back two responses.
-        use serde_json::json;
-        let mut transmission = Transmission::new(Options {
-            max_batch_size: 2,
-            batch_timeout: Duration::from_secs(5),
-            ..Options::default()
-        })
-        .unwrap();
-        transmission.start();
-
-        let api_host = &mockito::server_url();
-        let _m = mockito::mock(
-            "POST",
-            mockito::Matcher::Regex(r"/1/batch/(.*)$".to_string()),
-        )
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(
-            r#"
+            let api_host = &mockito::server_url();
+            let _m = mockito::mock(
+                "POST",
+                mockito::Matcher::Regex(r"/1/batch/(.*)$".to_string()),
+            )
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"
 [
   { "status":202 },
   { "status":202 }
 ]"#,
-        )
-        .create();
+            )
+            .create();
 
-        let mut event1 = Event::new(&client::Options {
-            api_key: "some_api_key".to_string(),
-            api_host: api_host.to_string(),
-            dataset: "same".to_string(),
-            ..client::Options::default()
-        });
-        event1.metadata = Some(json!("event1"));
-        let mut event2 = event1.clone();
-        event2.metadata = Some(json!("event2"));
-        let mut event3 = event1.clone();
-        event3.options.dataset = "other".to_string();
-        event3.metadata = Some(json!("event3"));
+            let mut event1 = Event::new(&client::Options {
+                api_key: "some_api_key".to_string(),
+                api_host: api_host.to_string(),
+                dataset: "same".to_string(),
+                ..client::Options::default()
+            });
+            event1.metadata = Some(json!("event1"));
+            let mut event2 = event1.clone();
+            event2.metadata = Some(json!("event2"));
+            let mut event3 = event1.clone();
+            event3.options.dataset = "other".to_string();
+            event3.metadata = Some(json!("event3"));
 
-        transmission.send(event3).await;
-        transmission.send(event2).await;
-        transmission.send(event1).await;
+            transmission.send(event3).await;
+            transmission.send(event2).await;
+            transmission.send(event1).await;
 
-        let response1 = transmission.responses().recv().await.unwrap();
-        let response2 = transmission.responses().recv().await.unwrap();
-        let _ = future::timeout(Duration::from_millis(250), transmission.responses().recv())
-            .await
-            .err();
+            let response1 = transmission.responses().recv().await.unwrap();
+            let response2 = transmission.responses().recv().await.unwrap();
+            let _ = future::timeout(Duration::from_millis(250), transmission.responses().recv())
+                .await
+                .err();
 
-        assert_eq!(response1.status_code, Some(StatusCode::ACCEPTED));
-        assert_eq!(response2.status_code, Some(StatusCode::ACCEPTED));
+            assert_eq!(response1.status_code, Some(StatusCode::ACCEPTED));
+            assert_eq!(response2.status_code, Some(StatusCode::ACCEPTED));
 
-        // Responses can come out of order so we check against any of the metadata
-        assert!(
-            response1.metadata == Some(json!("event1"))
-                || response1.metadata == Some(json!("event2"))
-        );
-        assert!(
-            response2.metadata == Some(json!("event1"))
-                || response2.metadata == Some(json!("event2"))
-        );
-        transmission.stop().await.unwrap().await.unwrap();
+            // Responses can come out of order so we check against any of the metadata
+            assert!(
+                response1.metadata == Some(json!("event1"))
+                    || response1.metadata == Some(json!("event2"))
+            );
+            assert!(
+                response2.metadata == Some(json!("event1"))
+                    || response2.metadata == Some(json!("event2"))
+            );
+            transmission.stop().await.unwrap().await.unwrap();
+        })
     }
 
-    #[async_std::test]
-    async fn test_bad_response() {
-        use serde_json::json;
+    #[test]
+    fn test_bad_response() {
+        run_with_supported_executors(|executor| async move {
+            use serde_json::json;
 
-        let mut transmission = Transmission::new(Options::default()).unwrap();
-        transmission.start();
+            let mut transmission = Transmission::new(executor, Options::default()).unwrap();
+            transmission.start().unwrap();
 
-        let api_host = &mockito::server_url();
-        let _m = mockito::mock(
-            "POST",
-            mockito::Matcher::Regex(r"/1/batch/(.*)$".to_string()),
-        )
-        .with_status(400)
-        .with_header("content-type", "application/json")
-        .with_body("request body is malformed and cannot be read as JSON")
-        .create();
+            let api_host = &mockito::server_url();
+            let _m = mockito::mock(
+                "POST",
+                mockito::Matcher::Regex(r"/1/batch/(.*)$".to_string()),
+            )
+            .with_status(400)
+            .with_header("content-type", "application/json")
+            .with_body("request body is malformed and cannot be read as JSON")
+            .create();
 
-        let mut event = Event::new(&client::Options {
-            api_key: "some_api_key".to_string(),
-            api_host: api_host.to_string(),
-            ..client::Options::default()
-        });
+            let mut event = Event::new(&client::Options {
+                api_key: "some_api_key".to_string(),
+                api_host: api_host.to_string(),
+                ..client::Options::default()
+            });
 
-        event.metadata = Some(json!("some metadata in a string"));
-        transmission.send(event).await;
+            event.metadata = Some(json!("some metadata in a string"));
+            transmission.send(event).await;
 
-        if let Ok(response) = transmission.responses().recv().await {
-            assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
-            assert_eq!(
-                response.body,
-                Some("request body is malformed and cannot be read as JSON".to_string())
-            );
-        } else {
-            panic!("did not receive an expected response");
-        }
-        transmission.stop().await.unwrap().await.unwrap();
+            if let Ok(response) = transmission.responses().recv().await {
+                assert_eq!(response.status_code, Some(StatusCode::BAD_REQUEST));
+                assert_eq!(
+                    response.body,
+                    Some("request body is malformed and cannot be read as JSON".to_string())
+                );
+            } else {
+                panic!("did not receive an expected response");
+            }
+            transmission.stop().await.unwrap().await.unwrap();
+        })
     }
 }


### PR DESCRIPTION
Currently, calling `flush` triggers an asynchronous flush but doesn't
provide the caller with a mechanism to wait for all queued events to
be flushed.

This PR changes the `Client::flush` and `Client::close` interfaces to be
`async` and fixes a few concurrency issues I ran into while making this
change:
* Replaces the non-async `crossbeam_channel` with `async_channel`.
  The `crossbeam_channel` crate blocks the current thread and isn't
  safe to use within an async executor. The timeout behavior is preserved
  using `future::timeout`.
* Avoids creating a new runtime within each `process_work` task. Instead,
  tasks are spawned within the `Transmission`'s runtime.
* Removes the `Mutex` around the runtime, which causes problems sharing
  the guards across threads and doesn't appear to be needed.
* When processing the stop event, flushes queued events before breaking
  out of the `process_work` loop (#65).

Resolves #66 and fixes #65.