### PR TITLE
Add honeycomb.io/ link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # libhoney-rust
 
-Rust library for sending data to Honeycomb.
+Rust library for sending data to [Honeycomb](https://www.honeycomb.io/).
 
 I'd be forever greatful if you can try it out and provide feedback. There are a few
 reasons why I think this may not yet be ready for production use:


### PR DESCRIPTION
It's not immediately clear when reading the readme which honeycomb this refers to, and "honeycomp" is a *very* common brand name on Github.

This PR adds a link to make it immediately clear what this crate refers to.